### PR TITLE
Scroll columns horizontally

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -21,14 +21,29 @@
 }
 
 #song {
-    column-count: 3;
     padding-left: 10px;
+    width: 100%;
+    height: 100%;
+    column-fill: auto;
+}
+
+#songContainer {
+    flex: auto;
+    position: relative;
 }
 
 #songView {
     position: relative;
     z-index: 0;
+    box-sizing: border-box;
+    display: flex;
+    flex-direction: column;
+    height: 100%;
     padding: 10px;
+}
+
+html#songPage, html#songPage body {
+    height: 100%;
 }
 
 #allSongs {

--- a/js/controller.js
+++ b/js/controller.js
@@ -50,6 +50,7 @@ const loadColumnButtons = function() {
 
   const updateColCount = function(colCount) {
     $("#song").css("column-count", colCount);
+    $("#song").css("position", colCount > 1 ? "absolute" : "static");
   }
 
   let defaultColCount = 3;

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html data-title="{{title}}" data-artist="{{artist}}">
+<html id="songPage" data-title="{{title}}" data-artist="{{artist}}">
 
 <head>
   <meta charset="utf-8">
@@ -51,7 +51,9 @@
         <span id="capoAmount"></span>
       </button>
     </h3>
-    <div id="song">
+    <div id="songContainer">
+      <div id="song">
+      </div>
     </div>
   </div>
   <div id="chordPics" title="Click to hide chord pictures">


### PR DESCRIPTION
The idea here is to try to reduce the amount of scrolling needed for songs that don’t fit completely on screen. Instead of scrolling down to the bottom of the first column, up to the top of the second column, down to the bottom of the second column, etc., now you can just scroll to the right.

Tested on Chrome 61, Edge 15, Firefox 57, and (with #25) IE 11. Probably should be tested on Safari.

Demo: https://musicparsed-andersk.herokuapp.com/