### PR TITLE
Make it work on IE11

### DIFF
--- a/js/convert/convert.js
+++ b/js/convert/convert.js
@@ -1,3 +1,4 @@
+import "babel-polyfill";
 import $ from "jquery";
 import "bootstrap/dist/css/bootstrap.min.css";
 import "../../css/convert.css";

--- a/js/import.js
+++ b/js/import.js
@@ -1,3 +1,4 @@
+import "babel-polyfill";
 import $ from "jquery";
 import "bootstrap/dist/css/bootstrap.min.css";
 import "../css/import.css";

--- a/js/index.js
+++ b/js/index.js
@@ -1,3 +1,4 @@
+import "babel-polyfill";
 import $ from "jquery";
 import {songView} from "./model.js";
 import {initRender, loadSong} from "./render.js";

--- a/js/render.js
+++ b/js/render.js
@@ -71,6 +71,7 @@ export var renderChords = function() {
     frets: instrumentData.frets,
     fretsPlusHalf: instrumentData.frets + 0.5,
     viewHeight: instrumentData.frets + 1.5,
+    height: (instrumentData.frets + 1.5) * 11,
     stringLines: Array.apply(null, Array(instrumentData.strings - 2)).map(function(_, i) {
       return i + 1;
     }),

--- a/js/showAllSongs.js
+++ b/js/showAllSongs.js
@@ -1,3 +1,4 @@
+import "babel-polyfill";
 import $ from "jquery";
 import "bootstrap/dist/css/bootstrap.min.css";
 import "../css/styles.css";

--- a/mustache/chords.mustache
+++ b/mustache/chords.mustache
@@ -6,7 +6,7 @@
     {{/unknown}}
     {{^unknown}}
       <div>
-        <svg width="{{width}}" viewBox="{{viewLeft}} -0.9 {{viewWidth}} {{viewHeight}}">
+        <svg width="{{width}}" height="{{height}}" viewBox="{{viewLeft}} -0.9 {{viewWidth}} {{viewHeight}}">
           {{^offset}}
             <rect x="0" y="0" width="{{stringsMinus1}}" height="{{fretsPlusHalf}}" fill="none" stroke="black" stroke-width="0.06" />
             <rect x="0" y="0" width="{{stringsMinus1}}" height="0.5" fill="black" />

--- a/package.json
+++ b/package.json
@@ -28,6 +28,8 @@
     "jquery": "^3.1.0",
     "jquery-ui": "^1.12.1",
     "mustache-loader": "^1.0.0",
+    "postcss-cssnext": "^3.0.2",
+    "postcss-loader": "^2.0.6",
     "style-loader": "^0.18.2",
     "url-loader": "^0.5.9",
     "webpack": "^3.5.6",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "babel-core": "^6.26.0",
     "babel-loader": "^7.1.2",
+    "babel-polyfill": "^6.26.0",
     "babel-preset-es2015": "^6.24.1",
     "bootstrap": "^3.3.7",
     "clean-webpack-plugin": "^0.1.16",

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+    plugins: [
+        require('postcss-cssnext'),
+    ],
+};

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -25,7 +25,16 @@ module.exports = {
             loader: 'mustache-loader'
         }, {
             test: /\.css$/,
-            use: ['style-loader', 'css-loader']
+            use: [{
+                loader: 'style-loader',
+            }, {
+                loader: 'css-loader',
+                options: {
+                    importLoaders: 1,
+                },
+            }, {
+                loader: 'postcss-loader',
+            }],
         }, {
             test: /\.(eot|png|svg|ttf|woff|woff2)$/,
             loader: 'url-loader',


### PR DESCRIPTION
Without babel-polyfill, IE11 just spews errors to the console and displays a blank song. The other changes make it look reasonable.

(Unfortunately, babel-polyfill bloats index.bundle.js from 351 kB to 440 kB, but if anyone were paying attention to that, it wouldn’t have been 351 kB in the first place.)