### PR TITLE
Improve keyboard accessibility of widgets

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -35,9 +35,6 @@
 #allSongs {
     column-count: 3;
 }
-.selected {
-    background-color: #fffddd;
-}
 
 .chords {
     display: block;

--- a/js/controller.js
+++ b/js/controller.js
@@ -1,4 +1,5 @@
 import $ from "jquery";
+import "bootstrap/js/button";
 import "jquery-ui/ui/widgets/tooltip";
 import "jquery-ui/themes/base/all.css";
 import {songView} from "./model.js";
@@ -14,8 +15,8 @@ const getWidget = function(type) {
 }
 
 const selectButton = function(type, value) {
-  $(`#${type}`).find("label").removeClass("selected");
-  $(`#${type}-${value}`).addClass('selected');
+  $(`#${type}`).find("label").removeClass("active");
+  $(`#${type}-${value}`).addClass("active").find("input").prop("checked", true);
 }
 
 const loadTransposeButtons = function() {
@@ -38,9 +39,8 @@ const loadTransposeButtons = function() {
 
   selectButton(transpose, 0);
 
-  $("#transpose").find("input").click(function(e) {
-    var newKey = $(e.target.parentNode).data()[transpose];
-    selectButton(transpose, newKey);
+  $("#transpose").find("input").change(function(e) {
+    const newKey = e.target.value;
     songView.setKey(newKey);
     rerender();
   });
@@ -77,9 +77,8 @@ const loadColumnButtons = function() {
 
   const columnWidget = getWidget(column);
 
-  columnWidget.find("input").click(function(e) {
-    const colCount = $(e.target.parentNode).data()[column];
-    selectButton(column, colCount);
+  columnWidget.find("input").change(function(e) {
+    const colCount = e.target.value;
     updateColCount(colCount);
   });
 }
@@ -102,10 +101,8 @@ const loadInstrumentButtons = function() {
 
   const instrumentWidget = getWidget(instrument);
 
-  $("#instrument").find("input").click(function(e) {
-    const newInstrument = $(e.target.parentNode).data()[instrument];
-
-    selectButton(instrument, newInstrument);
+  $("#instrument").find("input").change(function(e) {
+    const newInstrument = e.target.value;
     songView.setInstrument(newInstrument);
     renderChords();
   });

--- a/js/convert/convert.js
+++ b/js/convert/convert.js
@@ -1,4 +1,5 @@
 import $ from "jquery";
+import "bootstrap/js/button";
 import "bootstrap/dist/css/bootstrap.min.css";
 import "../../css/convert.css";
 import {Guitar, Ukulele, Note} from "./music.js";

--- a/mustache/button.mustache
+++ b/mustache/button.mustache
@@ -1,5 +1,5 @@
 <div class="btn-group" data-toggle="buttons">
   {{#buttons}}
-    <label class='btn btn-default' data-{{type}}={{value}} id={{type}}-{{value}}><input type='radio'> {{name}}</label>
+    <label class='btn btn-default' id={{type}}-{{value}}><input type='radio' name={{type}} value={{value}}> {{name}}</label>
   {{/buttons}}
 </div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -29,7 +29,7 @@
         <div class="ui-widget">
           <label for="tags">Song select: </label>
           <input id="tags">
-          <a href="/all"><button class="btn btn-default">Show all songs</button></a>
+          <a href="/all" class="btn btn-default" role="button">Show all songs</a>
           <label for="widgets">Widgets: </label>
           <button class="btn btn-default" id="viewToggle" title="Hide/show the column and transpose widgets">hide</button>
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -38,6 +38,9 @@ module.exports = {
         new CleanWebpackPlugin(['static/dist']),
         new WebpackManifestPlugin({
             publicPath: '/static/dist/'
+        }),
+        new webpack.ProvidePlugin({
+            jQuery: 'jquery'
         })
     ],
 };


### PR DESCRIPTION
Delegate button switching to Bootstrap's builtin code, which has slightly nicer styling, and shows you where the focus is while you navigate through the widgets with the tab and arrow keys.

Demo: https://musicparsed-andersk.herokuapp.com/