### PR TITLE
Resynchronize transpose button when rerendering song

### DIFF
--- a/js/controller.js
+++ b/js/controller.js
@@ -17,8 +17,11 @@ const getWidget = function(type) {
 };
 
 const selectButton = function(type, value) {
-  $(`#${type}`).find("label").removeClass("active");
-  $(`#${type}-${value}`).addClass("active").find("input").prop("checked", true);
+  const buttonToSelect = $(`#${type}-${value}`);
+  if (!buttonToSelect.find("input").prop("checked")) {
+    $(`#${type}`).find("label").removeClass("active");
+    buttonToSelect.addClass("active").find("input").prop("checked", true);
+  }
 };
 
 const loadChordOptionButtons = function() {
@@ -61,8 +64,7 @@ const loadTransposeButtons = function() {
   }
   document.getElementById(TRANSPOSE).innerHTML = buttonTemplate({ buttons: transposeButtons });
 
-  const transpose = songView.getTranspose();
-  selectButton(TRANSPOSE, transpose);
+  renderTranspose();
 
   const transposeWidget = getWidget(TRANSPOSE);
 
@@ -185,6 +187,11 @@ export var loadWidgets = function() {
 
   // Orientation toggle
   loadOrientationButtons();
+};
+
+export const renderTranspose = function() {
+  const transpose = songView.getTranspose();
+  selectButton(TRANSPOSE, transpose);
 };
 
 

--- a/js/render.js
+++ b/js/render.js
@@ -1,7 +1,7 @@
 import $ from "jquery";
 import "jquery-ui/ui/widgets/autocomplete";
 import "jquery-ui/themes/base/all.css";
-import { loadWidgets } from "./controller.js";
+import { loadWidgets, renderTranspose } from "./controller.js";
 import { pitchToFifths, songView } from "./model.js";
 import chordsTemplate from "../mustache/chords.mustache";
 import songTemplate from "../mustache/song.mustache";
@@ -201,6 +201,7 @@ export var rerender = function() {
   $("#title").text(fullName);
 
   document.getElementById("song").innerHTML = songTemplate(data);
+  renderTranspose();
   renderChords();
 };
 


### PR DESCRIPTION
This was removed in commit 23871bdd57679357786326a2837f65eb5bdf6099 because it was misbehaving with Bootstrap 4. To fix it, we just need to skip setting the `active` class when the input is already checked, since Bootstrap would then remove the `active` class with `toggleClass` when it was expecting to add it.