### PR TITLE
Remove String.prototype.trimEnd call

### DIFF
--- a/js/model.js
+++ b/js/model.js
@@ -29,7 +29,7 @@ const constructChord = function(totalLength, chords, offsets) {
   for(let i = 0; i < offsets.length; i++) {
     blankChord = blankChord.replaceAt(offsets[i], chords[i]);
   }
-  return blankChord.trimEnd();
+  return blankChord;
 };
 
 // Make complicated chords easier for beginners


### PR DESCRIPTION
IE/Edge doesn’t support it, and it’s still a stage 3 proposal so it’s not enabled in @babel/polyfill by default.  We could add the polyfill, but this particular call has no effect anymore so we can just remove it.

(For a minute I was scared I broke this with #92, but no, it’s actually been broken for longer.)