### PR TITLE
Support backfilling the Mongo DB

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,3 @@
+seed:
+	npm run parser seed # This creates ALL_SONGS_DATA.json
+	mongoimport --db=musicparsed --collection=songs --drop --jsonArray < static/data/ALL_SONGS_DATA.json

--- a/README.md
+++ b/README.md
@@ -5,6 +5,11 @@ Start local server:
     yarn
     yarn app
 
+Seed local Mongo DB:
+
+    make seed
+
+
 Useful commands:
 
     yarn watch

--- a/scripts/parser-cli.ts
+++ b/scripts/parser-cli.ts
@@ -4,16 +4,14 @@ import { slugify, parseLines } from "../lib/parser";
 import fs from "fs";
 import path from "path";
 
-const textDir = path.resolve(__dirname, "..", "static", "data", "text");
-const tagsDir = path.resolve(__dirname, "..", "static", "data", "tags");
-const jsonDir = path.resolve(__dirname, "..", "static", "data", "json");
-const allSongsPath = path.resolve(
-  __dirname,
-  "..",
-  "static",
-  "data",
-  "ALL_SONGS.json"
-);
+const dataDir = path.resolve(__dirname, "..", "static", "data");
+const textDir = path.resolve(dataDir, "text");
+const tagsDir = path.resolve(dataDir, "tags");
+const jsonDir = path.resolve(dataDir, "json");
+const allSongsPath = path.resolve(dataDir, "ALL_SONGS.json");
+
+// Load data from all songs into 1 giant JSON to populate Mongo
+const allSongsDataPath = path.resolve(dataDir, "ALL_SONGS_DATA.json");
 
 const fields = [
   "allChords",
@@ -56,6 +54,7 @@ for (const [tag, ids] of tags) {
   }
 }
 
+const allSongData: string[] = [];
 const allSongs = fs
   .readdirSync(textDir)
   .map(filename => /^(.*) - (.*)\.txt$/.exec(filename))
@@ -68,7 +67,9 @@ const allSongs = fs
     });
     const songData = parseLines({ title, artist, songText });
     const songJson = JSON.stringify(songData, fields, 2);
+    allSongData.push(songJson);
 
+    // Update JSON file
     const songPath = path.resolve(jsonDir, `${songData.id}.json`);
     if (
       !fs.existsSync(songPath) ||
@@ -99,4 +100,9 @@ if (
 ) {
   console.log(allSongsPath);
   fs.writeFileSync(allSongsPath, allSongsJson);
+}
+
+const args = process.argv;
+if (args[2] === "seed") {
+  fs.writeFileSync(allSongsDataPath, `[${allSongData}]`);
 }


### PR DESCRIPTION
- Update parser cli to enable seeding the database from ALL_SONG_DATA.json.
- Add Make command for setting up the dev DB. In the future, since we should be able to delete the static/data folder, this command will do something different e.g. only seed a handful of songs.